### PR TITLE
Replace browser.extension.getURL

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -5,7 +5,7 @@ function openMyPage() {
 }
 
 function onVisited(historyItem) {
-  if (historyItem.url == browser.extension.getURL("./index.html")) {
+  if (historyItem.url == browser.runtime.getURL("./index.html")) {
     browser.history.deleteUrl({url: historyItem.url});
   }
 }


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/extension/getURL is deprecated and results in an error with Firefox 95.x on Windows. The documentation says it should be replaced with https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/getURL